### PR TITLE
Small fix to URLs for libpng and SDL

### DIFF
--- a/dependencies/scripts/build-libpng.sh
+++ b/dependencies/scripts/build-libpng.sh
@@ -4,9 +4,9 @@
 
 if [ ! -f $CACHEROOT/libpng-$LIBPNG_VERSION.tar.gz ]; then
   echo 'Downloading libpng source'
-  echo http://downloads.sourceforge.net/project/libpng/libpng16/$LIBPNG_VERSION/libpng-$LIBPNG_VERSION.tar.gz
+  echo $LIBPNG_URL_PREFIX/$LIBPNG_VERSION/libpng-$LIBPNG_VERSION.tar.gz
 
-  try curl -L http://downloads.sourceforge.net/project/libpng/libpng16/$LIBPNG_VERSION/libpng-$LIBPNG_VERSION.tar.gz > $CACHEROOT/libpng-$LIBPNG_VERSION.tar.gz
+  try curl -L $LIBPNG_URL_PREFIX/$LIBPNG_VERSION/libpng-$LIBPNG_VERSION.tar.gz > $CACHEROOT/libpng-$LIBPNG_VERSION.tar.gz
 fi
 
 try rm -rf $TMPROOT/libpng-$LIBPNG_VERSION

--- a/dependencies/scripts/environment.sh
+++ b/dependencies/scripts/environment.sh
@@ -42,12 +42,14 @@ export FRIBIDI_VERSION=0.19.2
 
 
 export SDL_VERSION=2.0.4
-export SDL_URL_PREFIX=https://www.libsdl.org/tmp/release/
+export SDL_URL_PREFIX=https://www.libsdl.org/release
+
+export LIBPNG_VERSION=1.6.18
+export LIBPNG_URL_PREFIX=http://downloads.sourceforge.net/project/libpng/libpng16/older-releases
 
 export SDL2_GFX_VERSION=1.0.1
 export SDL2_TTF_VERSION=2.0.12
 export SDL2_IMAGE_VERSION=2.0.1
-export LIBPNG_VERSION=1.6.18
 export LIBJPEG_TURBO_VERSION=1.4.1
 export FFI_VERSION=3.2.1
 export FFMPEG_VERSION=3.0


### PR DESCRIPTION
A few URLs have changed so I figured I'd update them.

All SDL releases are in the folder I linked (including new ones) so it probably wouldn't need to be changed again. The libpng link would have to be updated if the dependency was updated to a more recent release.

Fribidi is another link that doesn't work but I'll be opening an issue for that since it is a bit more complicated than correcting a link.

Thanks for such a great project!