### PR TITLE
Switched Fribidi's URL to renpy-deps

### DIFF
--- a/dependencies/scripts/build-fribidi.sh
+++ b/dependencies/scripts/build-fribidi.sh
@@ -4,7 +4,7 @@
 
 if [ ! -f $CACHEROOT/fribidi-$FRIBIDI_VERSION.tar.gz ]; then
   echo "Downloading fribidi source"
-  try curl -L http://www.fribidi.org/download/fribidi-$FRIBIDI_VERSION.tar.gz > $CACHEROOT/fribidi-$FRIBIDI_VERSION.tar.gz
+  try curl -L $FRIBIDI_URL_PREFIX/fribidi-$FRIBIDI_VERSION.tar.gz?raw=true > $CACHEROOT/fribidi-$FRIBIDI_VERSION.tar.gz
 fi
 if [ ! -d $TMPROOT/fribidi-$FRIBIDI_VERSION ]; then
   try rm -rf $TMPROOT/fribidi-$FRIBIDI_VERSION

--- a/dependencies/scripts/environment.sh
+++ b/dependencies/scripts/environment.sh
@@ -38,14 +38,15 @@ export PYTHON_VERSION=2.7.3
 # export RENPY_VERSION=6.14.1
 # export PYGAME_VERSION=1.9.1
 export FREETYPE_VERSION=2.4.12
-export FRIBIDI_VERSION=0.19.2
-
 
 export SDL_VERSION=2.0.4
 export SDL_URL_PREFIX=https://www.libsdl.org/release
 
 export LIBPNG_VERSION=1.6.18
 export LIBPNG_URL_PREFIX=http://downloads.sourceforge.net/project/libpng/libpng16/older-releases
+
+export FRIBIDI_URL_PREFIX=https://github.com/renpy/renpy-deps/blob/master/source
+export FRIBIDI_VERSION=0.19.2
 
 export SDL2_GFX_VERSION=1.0.1
 export SDL2_TTF_VERSION=2.0.12


### PR DESCRIPTION
Because the Fribidi project now no longer hosts the version that Renpy uses, Renios's Fribidi build script now downloads from renpy/renpy-deps. This resolves issue #3.

Sorry for being late with finishing this up.